### PR TITLE
feature/prevent-logging-internal-messages-as-errors

### DIFF
--- a/src/KissLog.CloudListeners/Constants.cs
+++ b/src/KissLog.CloudListeners/Constants.cs
@@ -2,6 +2,6 @@
 {
     internal class Constants
     {
-        public const string KissLogApiUrl = "https://api.kisslog.net";
+        public const string LogBeeApiUrl = "https://api.logbee.net";
     }
 }

--- a/src/KissLog.CloudListeners/RequestLogsListener/RequestLogsApiListener.cs
+++ b/src/KissLog.CloudListeners/RequestLogsListener/RequestLogsApiListener.cs
@@ -17,7 +17,7 @@ namespace KissLog.CloudListeners.RequestLogsListener
         public ILogListenerInterceptor Interceptor { get; set; }
 
         public bool UseAsync { get; set; } = true;
-        public string ApiUrl { get; set; } = Constants.KissLogApiUrl;
+        public string ApiUrl { get; set; } = Constants.LogBeeApiUrl;
         public bool IgnoreSslCertificate { get; set; } = false;
         public Action<ExceptionArgs> OnException { get; set; }
         public IObfuscationService ObfuscationService { get; set; } = new ObfuscationService();

--- a/src/KissLog/KissLog.csproj
+++ b/src/KissLog/KissLog.csproj
@@ -75,7 +75,7 @@ Install this package on all the projects.</Description>
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="8.0.3" />
+    <PackageReference Include="System.Text.Json" Version="8.0.4" />
   </ItemGroup>
 
 </Project>

--- a/src/KissLog/LoggerData/FilesContainer.cs
+++ b/src/KissLog/LoggerData/FilesContainer.cs
@@ -31,7 +31,7 @@ namespace KissLog.LoggerData
 
             if(fileSize > Constants.MaximumAllowedFileSizeInBytes)
             {
-                _logger.Error(new FileSizeTooLargeException(fileSize, Constants.MaximumAllowedFileSizeInBytes));
+                _logger.Debug(new FileSizeTooLargeException(fileSize, Constants.MaximumAllowedFileSizeInBytes).ToString());
                 return null;
             }
 
@@ -69,7 +69,7 @@ namespace KissLog.LoggerData
 
             if (fileSize > Constants.MaximumAllowedFileSizeInBytes)
             {
-                _logger.Error(new FileSizeTooLargeException(fileSize, Constants.MaximumAllowedFileSizeInBytes));
+                _logger.Debug(new FileSizeTooLargeException(fileSize, Constants.MaximumAllowedFileSizeInBytes).ToString());
                 return null;
             }
 
@@ -91,7 +91,7 @@ namespace KissLog.LoggerData
                 if (temporaryFile != null)
                     temporaryFile.Dispose();
 
-                _logger.Error(new LogByteArrayAsFileException(contents, ex));
+                _logger.Debug(new LogByteArrayAsFileException(contents, ex).ToString());
 
                 return null;
             }
@@ -108,13 +108,13 @@ namespace KissLog.LoggerData
 
             if(!fi.Exists)
             {
-                _logger.Error(new LogFileException(sourceFilePath, new FileNotFoundException(null, sourceFilePath)));
+                _logger.Debug(new LogFileException(sourceFilePath, new FileNotFoundException(null, sourceFilePath)).ToString());
                 return null;
             }
 
             if (fi.Length > Constants.MaximumAllowedFileSizeInBytes)
             {
-                _logger.Error(new FileSizeTooLargeException(fi.Length, Constants.MaximumAllowedFileSizeInBytes));
+                _logger.Debug(new FileSizeTooLargeException(fi.Length, Constants.MaximumAllowedFileSizeInBytes).ToString());
                 return null;
             }
 
@@ -138,7 +138,7 @@ namespace KissLog.LoggerData
                 if (temporaryFile != null)
                     temporaryFile.Dispose();
 
-                _logger.Error(new LogFileException(sourceFilePath, ex));
+                _logger.Debug(new LogFileException(sourceFilePath, ex).ToString());
 
                 return null;
             }

--- a/testApps/AspNet.Mvc/AspNet.Mvc.csproj
+++ b/testApps/AspNet.Mvc/AspNet.Mvc.csproj
@@ -1,5 +1,4 @@
 ﻿<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props" Condition="Exists('packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -46,6 +45,9 @@
   <ItemGroup>
     <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>packages\Microsoft.Bcl.AsyncInterfaces.8.0.0\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=4.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.4.1.0\lib\net472\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Web.Infrastructure, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -109,11 +111,6 @@
     <Reference Include="System.Web.Services" />
     <Reference Include="System.EnterpriseServices" />
     <Reference Include="System.Xml.Linq" />
-  </ItemGroup>
-  <ItemGroup>
-    <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform">
-      <HintPath>packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\lib\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Content Include="Global.asax" />
@@ -185,11 +182,12 @@
       </FlavorProperties>
     </VisualStudio>
   </ProjectExtensions>
+  <Import Project="packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.4.1.0\build\net472\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.targets" Condition="Exists('packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.4.1.0\build\net472\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props'))" />
+    <Error Condition="!Exists('packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.4.1.0\build\net472\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.4.1.0\build\net472\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.targets'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/testApps/AspNet.Mvc/AspNet.Mvc.csproj
+++ b/testApps/AspNet.Mvc/AspNet.Mvc.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>AspNet.Mvc</RootNamespace>
     <AssemblyName>AspNet.Mvc</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>
     <UseIISExpress>true</UseIISExpress>
     <Use64BitIISExpress />
     <IISExpressSSLPort />
@@ -44,29 +44,32 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=5.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.Bcl.AsyncInterfaces.5.0.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>packages\Microsoft.Bcl.AsyncInterfaces.8.0.0\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.Web.Infrastructure, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>packages\Microsoft.Web.Infrastructure.2.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
+    </Reference>
     <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
     </Reference>
     <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>packages\System.Memory.4.5.4\lib\net461\System.Memory.dll</HintPath>
+    <Reference Include="System.Memory, Version=4.0.1.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>packages\System.Memory.4.5.5\lib\net461\System.Memory.dll</HintPath>
     </Reference>
     <Reference Include="System.Numerics" />
     <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
     </Reference>
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>packages\System.Runtime.CompilerServices.Unsafe.5.0.0\lib\net45\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>packages\System.Runtime.CompilerServices.Unsafe.6.0.0\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
-    <Reference Include="System.Text.Encodings.Web, Version=5.0.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>packages\System.Text.Encodings.Web.5.0.1\lib\net461\System.Text.Encodings.Web.dll</HintPath>
+    <Reference Include="System.Text.Encodings.Web, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>packages\System.Text.Encodings.Web.8.0.0\lib\net462\System.Text.Encodings.Web.dll</HintPath>
     </Reference>
-    <Reference Include="System.Text.Json, Version=5.0.0.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>packages\System.Text.Json.5.0.2\lib\net461\System.Text.Json.dll</HintPath>
+    <Reference Include="System.Text.Json, Version=8.0.0.4, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>packages\System.Text.Json.8.0.4\lib\net462\System.Text.Json.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
@@ -80,9 +83,27 @@
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Web" />
+    <Reference Include="System.Web.Extensions" />
+    <Reference Include="System.Web.Helpers, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>packages\Microsoft.AspNet.WebPages.3.3.0\lib\net45\System.Web.Helpers.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Mvc, Version=5.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>packages\Microsoft.AspNet.Mvc.5.3.0\lib\net45\System.Web.Mvc.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>packages\Microsoft.AspNet.Razor.3.3.0\lib\net45\System.Web.Razor.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.WebPages, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>packages\Microsoft.AspNet.WebPages.3.3.0\lib\net45\System.Web.WebPages.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.WebPages.Deployment, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>packages\Microsoft.AspNet.WebPages.3.3.0\lib\net45\System.Web.WebPages.Deployment.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.WebPages.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>packages\Microsoft.AspNet.WebPages.3.3.0\lib\net45\System.Web.WebPages.Razor.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Web.Services" />
@@ -90,27 +111,6 @@
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="System.Web.Razor">
-      <HintPath>packages\Microsoft.AspNet.Razor.3.2.7\lib\net45\System.Web.Razor.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Web.Webpages">
-      <HintPath>packages\Microsoft.AspNet.Webpages.3.2.7\lib\net45\System.Web.Webpages.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Web.Webpages.Deployment">
-      <HintPath>packages\Microsoft.AspNet.Webpages.3.2.7\lib\net45\System.Web.Webpages.Deployment.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Web.Webpages.Razor">
-      <HintPath>packages\Microsoft.AspNet.Webpages.3.2.7\lib\net45\System.Web.Webpages.Razor.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Web.Helpers">
-      <HintPath>packages\Microsoft.AspNet.Webpages.3.2.7\lib\net45\System.Web.Helpers.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Web.Infrastructure">
-      <HintPath>packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Web.Mvc">
-      <HintPath>packages\Microsoft.AspNet.Mvc.5.2.7\lib\net45\System.Web.Mvc.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform">
       <HintPath>packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\lib\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>
     </Reference>

--- a/testApps/AspNet.Mvc/Global.asax.cs
+++ b/testApps/AspNet.Mvc/Global.asax.cs
@@ -65,9 +65,9 @@ namespace AspNet.Mvc
 
             // register listeners
             KissLogConfiguration.Listeners
-                .Add(new RequestLogsApiListener(new Application(ConfigurationManager.AppSettings["KissLog.OrganizationId"], ConfigurationManager.AppSettings["KissLog.ApplicationId"]))
+                .Add(new RequestLogsApiListener(new Application(ConfigurationManager.AppSettings["LogBee.OrganizationId"], ConfigurationManager.AppSettings["LogBee.ApplicationId"]))
                 {
-                    ApiUrl = ConfigurationManager.AppSettings["KissLog.ApiUrl"],
+                    ApiUrl = ConfigurationManager.AppSettings["LogBee.ApiUrl"],
                     Interceptor = new StatusCodeInterceptor
                     {
                         MinimumLogMessageLevel = LogLevel.Trace,

--- a/testApps/AspNet.Mvc/Web.config
+++ b/testApps/AspNet.Mvc/Web.config
@@ -1,14 +1,14 @@
-﻿<?xml version="1.0"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!--
   For more information on how to configure your ASP.NET application, please visit
   https://go.microsoft.com/fwlink/?LinkId=301880
   -->
 <configuration>
   <appSettings>
-    <add key="webpages:Version" value="3.0.0.0"/>
-    <add key="webpages:Enabled" value="false"/>
-    <add key="ClientValidationEnabled" value="true"/>
-    <add key="UnobtrusiveJavaScriptEnabled" value="true"/>
+    <add key="webpages:Version" value="3.0.0.0" />
+    <add key="webpages:Enabled" value="false" />
+    <add key="ClientValidationEnabled" value="true" />
+    <add key="UnobtrusiveJavaScriptEnabled" value="true" />
     <add key="LogBee.OrganizationId" value="0337cd29-a56e-42c1-a48a-e900f3116aa8" />
     <add key="LogBee.ApplicationId" value="4f729841-b103-460e-a87c-be6bd72f0cc9" />
     <add key="LogBee.ApiUrl" value="https://api.logbee.net/" />
@@ -22,37 +22,37 @@
       </system.Web>
   -->
   <system.web>
-    <compilation debug="true" targetFramework="4.8.1"/>
-    <httpRuntime targetFramework="4.7.2"/>
+    <compilation debug="true" targetFramework="4.8.1" />
+    <httpRuntime targetFramework="4.7.2" />
   </system.web>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0"/>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35"/>
-        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0"/>
+        <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35"/>
-        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0"/>
+        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35"/>
-        <bindingRedirect oldVersion="1.0.0.0-5.3.0.0" newVersion="5.3.0.0"/>
+        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-5.3.0.0" newVersion="5.3.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Web.Infrastructure" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0"/>
+        <assemblyIdentity name="Microsoft.Web.Infrastructure" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <system.codedom>
     <compilers>
-      <compiler language="c#;cs;csharp" extension=".cs" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=2.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:default /nowarn:1659;1699;1701"/>
-      <compiler language="vb;vbs;visualbasic;vbscript" extension=".vb" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=2.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:default /nowarn:41008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+"/>
+      <compiler language="c#;cs;csharp" extension=".cs" warningLevel="4" compilerOptions="/langversion:default /nowarn:1659;1699;1701;612;618" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=4.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+      <compiler language="vb;vbs;visualbasic;vbscript" extension=".vb" warningLevel="4" compilerOptions="/langversion:default /nowarn:41008,40000,40008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=4.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
     </compilers>
   </system.codedom>
 </configuration>

--- a/testApps/AspNet.Mvc/Web.config
+++ b/testApps/AspNet.Mvc/Web.config
@@ -9,16 +9,28 @@
     <add key="webpages:Enabled" value="false"/>
     <add key="ClientValidationEnabled" value="true"/>
     <add key="UnobtrusiveJavaScriptEnabled" value="true"/>
-    <add key="KissLog.OrganizationId" value="0337cd29-a56e-42c1-a48a-e900f3116aa8" />
-    <add key="KissLog.ApplicationId" value="4f729841-b103-460e-a87c-be6bd72f0cc9" />
-    <add key="KissLog.ApiUrl" value="https://api.kisslog.net" />
+    <add key="KissLog.OrganizationId" value="0337cd29-a56e-42c1-a48a-e900f3116aa8"/>
+    <add key="KissLog.ApplicationId" value="4f729841-b103-460e-a87c-be6bd72f0cc9"/>
+    <add key="KissLog.ApiUrl" value="https://api.kisslog.net"/>
   </appSettings>
+  <!--
+    For a description of web.config changes see http://go.microsoft.com/fwlink/?LinkId=235367.
+
+    The following attributes can be set on the <httpRuntime> tag.
+      <system.Web>
+        <httpRuntime targetFramework="4.8.1" />
+      </system.Web>
+  -->
   <system.web>
-    <compilation debug="true" targetFramework="4.7.2"/>
-    <httpRuntime targetFramework="4.7.2" />
+    <compilation debug="true" targetFramework="4.8.1"/>
+    <httpRuntime targetFramework="4.7.2"/>
   </system.web>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0"/>
+      </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35"/>
         <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0"/>
@@ -29,11 +41,11 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35"/>
-        <bindingRedirect oldVersion="1.0.0.0-5.2.7.0" newVersion="5.2.7.0"/>
+        <bindingRedirect oldVersion="1.0.0.0-5.3.0.0" newVersion="5.3.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0"/>
+        <assemblyIdentity name="Microsoft.Web.Infrastructure" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/testApps/AspNet.Mvc/Web.config
+++ b/testApps/AspNet.Mvc/Web.config
@@ -9,9 +9,9 @@
     <add key="webpages:Enabled" value="false"/>
     <add key="ClientValidationEnabled" value="true"/>
     <add key="UnobtrusiveJavaScriptEnabled" value="true"/>
-    <add key="KissLog.OrganizationId" value="0337cd29-a56e-42c1-a48a-e900f3116aa8"/>
-    <add key="KissLog.ApplicationId" value="4f729841-b103-460e-a87c-be6bd72f0cc9"/>
-    <add key="KissLog.ApiUrl" value="https://api.kisslog.net"/>
+    <add key="LogBee.OrganizationId" value="0337cd29-a56e-42c1-a48a-e900f3116aa8" />
+    <add key="LogBee.ApplicationId" value="4f729841-b103-460e-a87c-be6bd72f0cc9" />
+    <add key="LogBee.ApiUrl" value="https://api.logbee.net/" />
   </appSettings>
   <!--
     For a description of web.config changes see http://go.microsoft.com/fwlink/?LinkId=235367.

--- a/testApps/AspNet.Mvc/packages.config
+++ b/testApps/AspNet.Mvc/packages.config
@@ -4,7 +4,7 @@
   <package id="Microsoft.AspNet.Razor" version="3.3.0" targetFramework="net472" />
   <package id="Microsoft.AspNet.WebPages" version="3.3.0" targetFramework="net472" />
   <package id="Microsoft.Bcl.AsyncInterfaces" version="8.0.0" targetFramework="net472" />
-  <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="2.0.1" targetFramework="net461" />
+  <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="4.1.0" targetFramework="net481" />
   <package id="Microsoft.Web.Infrastructure" version="2.0.0" targetFramework="net472" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net461" />
   <package id="System.Memory" version="4.5.5" targetFramework="net472" />

--- a/testApps/AspNet.Mvc/packages.config
+++ b/testApps/AspNet.Mvc/packages.config
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.AspNet.Mvc" version="5.2.7" targetFramework="net461" />
-  <package id="Microsoft.AspNet.Razor" version="3.2.7" targetFramework="net461" />
-  <package id="Microsoft.AspNet.WebPages" version="3.2.7" targetFramework="net461" />
-  <package id="Microsoft.Bcl.AsyncInterfaces" version="5.0.0" targetFramework="net461" />
+  <package id="Microsoft.AspNet.Mvc" version="5.3.0" targetFramework="net472" />
+  <package id="Microsoft.AspNet.Razor" version="3.3.0" targetFramework="net472" />
+  <package id="Microsoft.AspNet.WebPages" version="3.3.0" targetFramework="net472" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="8.0.0" targetFramework="net472" />
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="2.0.1" targetFramework="net461" />
-  <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net461" />
+  <package id="Microsoft.Web.Infrastructure" version="2.0.0" targetFramework="net472" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net461" />
-  <package id="System.Memory" version="4.5.4" targetFramework="net461" />
+  <package id="System.Memory" version="4.5.5" targetFramework="net472" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net461" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="5.0.0" targetFramework="net461" />
-  <package id="System.Text.Encodings.Web" version="5.0.1" targetFramework="net461" />
-  <package id="System.Text.Json" version="5.0.2" targetFramework="net461" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="net472" />
+  <package id="System.Text.Encodings.Web" version="8.0.0" targetFramework="net472" />
+  <package id="System.Text.Json" version="8.0.4" targetFramework="net472" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net461" />
-  <package id="System.ValueTuple" version="4.5.0" targetFramework="net461" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net461" requireReinstallation="true" />
 </packages>

--- a/testApps/AspNet.WebApi/AspNet.WebApi.csproj
+++ b/testApps/AspNet.WebApi/AspNet.WebApi.csproj
@@ -43,20 +43,36 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=3.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.3.6.0\lib\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>
+    <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=4.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.4.1.0\lib\net472\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>packages\Newtonsoft.Json.13.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json.Bson, Version=1.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>packages\Newtonsoft.Json.Bson.1.0.2\lib\net45\Newtonsoft.Json.Bson.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
     </Reference>
     <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Memory, Version=4.0.1.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>packages\System.Memory.4.5.5\lib\net461\System.Memory.dll</HintPath>
+    </Reference>
     <Reference Include="System.Net.Http" />
-    <Reference Include="System.Net.Http.Formatting, Version=5.2.9.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.AspNet.WebApi.Client.5.2.9\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+    <Reference Include="System.Net.Http.Formatting, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>packages\Microsoft.AspNet.WebApi.Client.6.0.0\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>packages\System.Runtime.CompilerServices.Unsafe.6.0.0\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.DynamicData" />
     <Reference Include="System.Web.Entity" />
@@ -67,11 +83,11 @@
     <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Web" />
-    <Reference Include="System.Web.Http, Version=5.2.9.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.AspNet.WebApi.Core.5.2.9\lib\net45\System.Web.Http.dll</HintPath>
+    <Reference Include="System.Web.Http, Version=5.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>packages\Microsoft.AspNet.WebApi.Core.5.3.0\lib\net45\System.Web.Http.dll</HintPath>
     </Reference>
-    <Reference Include="System.Web.Http.WebHost, Version=5.2.9.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.AspNet.WebApi.WebHost.5.2.9\lib\net45\System.Web.Http.WebHost.dll</HintPath>
+    <Reference Include="System.Web.Http.WebHost, Version=5.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>packages\Microsoft.AspNet.WebApi.WebHost.5.3.0\lib\net45\System.Web.Http.WebHost.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="System.Configuration" />
@@ -100,7 +116,6 @@
       <DependentUpon>Web.config</DependentUpon>
     </None>
   </ItemGroup>
-  <ItemGroup />
   <ItemGroup>
     <ProjectReference Include="..\..\src\KissLog.AspNet.WebApi\KissLog.AspNet.WebApi.csproj">
       <Project>{8b09066a-48cc-41df-959e-6a6beb26ddce}</Project>
@@ -144,12 +159,12 @@
       </FlavorProperties>
     </VisualStudio>
   </ProjectExtensions>
-  <Import Project="packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.3.6.0\build\net472\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.targets" Condition="Exists('packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.3.6.0\build\net472\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.targets')" />
+  <Import Project="packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.4.1.0\build\net472\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.targets" Condition="Exists('packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.4.1.0\build\net472\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.3.6.0\build\net472\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.3.6.0\build\net472\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.targets'))" />
+    <Error Condition="!Exists('packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.4.1.0\build\net472\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.4.1.0\build\net472\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.targets'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/testApps/AspNet.WebApi/Global.asax.cs
+++ b/testApps/AspNet.WebApi/Global.asax.cs
@@ -60,9 +60,9 @@ namespace AspNet.WebApi
 
             // register listeners
             KissLogConfiguration.Listeners
-                .Add(new RequestLogsApiListener(new Application(ConfigurationManager.AppSettings["KissLog.OrganizationId"], ConfigurationManager.AppSettings["KissLog.ApplicationId"]))
+                .Add(new RequestLogsApiListener(new Application(ConfigurationManager.AppSettings["LogBee.OrganizationId"], ConfigurationManager.AppSettings["LogBee.ApplicationId"]))
                 {
-                    ApiUrl = ConfigurationManager.AppSettings["KissLog.ApiUrl"],
+                    ApiUrl = ConfigurationManager.AppSettings["LogBee.ApiUrl"],
                     Interceptor = new StatusCodeInterceptor
                     {
                         MinimumLogMessageLevel = LogLevel.Trace,

--- a/testApps/AspNet.WebApi/Web.config
+++ b/testApps/AspNet.WebApi/Web.config
@@ -41,12 +41,6 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-  <system.codedom>
-    <compilers>
-      <compiler extension=".cs" language="c#;cs;csharp" warningLevel="4" compilerOptions="/langversion:7.3 /nowarn:1659;1699;1701;612;618" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=3.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
-      <compiler extension=".vb" language="vb;vbs;visualbasic;vbscript" warningLevel="4" compilerOptions="/langversion:default /nowarn:41008,40000,40008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=3.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
-    </compilers>
-  </system.codedom>
   <system.webServer>
     <handlers>
       <remove name="ExtensionlessUrlHandler-Integrated-4.0" />
@@ -55,4 +49,10 @@
       <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="*" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0" />
     </handlers>
   </system.webServer>
+  <system.codedom>
+    <compilers>
+      <compiler language="c#;cs;csharp" extension=".cs" warningLevel="4" compilerOptions="/langversion:default /nowarn:1659;1699;1701;612;618" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=4.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+      <compiler language="vb;vbs;visualbasic;vbscript" extension=".vb" warningLevel="4" compilerOptions="/langversion:default /nowarn:41008,40000,40008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=4.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+    </compilers>
+  </system.codedom>
 </configuration>

--- a/testApps/AspNet.WebApi/Web.config
+++ b/testApps/AspNet.WebApi/Web.config
@@ -5,9 +5,9 @@
   -->
 <configuration>
   <appSettings>
-    <add key="KissLog.OrganizationId" value="0337cd29-a56e-42c1-a48a-e900f3116aa8" />
-    <add key="KissLog.ApplicationId" value="4f729841-b103-460e-a87c-be6bd72f0cc9" />
-    <add key="KissLog.ApiUrl" value="https://api.kisslog.net" />
+    <add key="LogBee.OrganizationId" value="0337cd29-a56e-42c1-a48a-e900f3116aa8" />
+    <add key="LogBee.ApplicationId" value="4f729841-b103-460e-a87c-be6bd72f0cc9" />
+    <add key="LogBee.ApiUrl" value="https://api.logbee.net/" />
   </appSettings>
   <system.web>
     <compilation debug="true" targetFramework="4.7.2" />

--- a/testApps/AspNet.WebApi/packages.config
+++ b/testApps/AspNet.WebApi/packages.config
@@ -1,10 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.AspNet.WebApi" version="5.2.9" targetFramework="net472" />
-  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.9" targetFramework="net472" />
-  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.9" targetFramework="net472" />
-  <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.9" targetFramework="net472" />
-  <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="3.6.0" targetFramework="net472" />
-  <package id="Newtonsoft.Json" version="13.0.2" targetFramework="net472" />
+  <package id="Microsoft.AspNet.WebApi" version="5.3.0" targetFramework="net472" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="6.0.0" targetFramework="net472" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.3.0" targetFramework="net472" />
+  <package id="Microsoft.AspNet.WebApi.WebHost" version="5.3.0" targetFramework="net472" />
+  <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="4.1.0" targetFramework="net472" />
+  <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net472" />
+  <package id="Newtonsoft.Json.Bson" version="1.0.2" targetFramework="net472" />
+  <package id="System.Buffers" version="4.5.1" targetFramework="net472" />
+  <package id="System.Memory" version="4.5.5" targetFramework="net472" />
+  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net472" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="net472" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net472" />
 </packages>

--- a/testApps/NLog_AspNet.Mvc/Global.asax.cs
+++ b/testApps/NLog_AspNet.Mvc/Global.asax.cs
@@ -60,9 +60,9 @@ namespace NLog_AspNet.Mvc
 
             // register listeners
             KissLogConfiguration.Listeners
-                .Add(new RequestLogsApiListener(new KissLog.CloudListeners.Auth.Application(ConfigurationManager.AppSettings["KissLog.OrganizationId"], ConfigurationManager.AppSettings["KissLog.ApplicationId"]))
+                .Add(new RequestLogsApiListener(new KissLog.CloudListeners.Auth.Application(ConfigurationManager.AppSettings["LogBee.OrganizationId"], ConfigurationManager.AppSettings["LogBee.ApplicationId"]))
                 {
-                    ApiUrl = ConfigurationManager.AppSettings["KissLog.ApiUrl"],
+                    ApiUrl = ConfigurationManager.AppSettings["LogBee.ApiUrl"],
                     Interceptor = new StatusCodeInterceptor
                     {
                         MinimumLogMessageLevel = LogLevel.Trace,

--- a/testApps/NLog_AspNet.Mvc/NLog_AspNet.Mvc.csproj
+++ b/testApps/NLog_AspNet.Mvc/NLog_AspNet.Mvc.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>NLog_AspNet.Mvc</RootNamespace>
     <AssemblyName>NLog_AspNet.Mvc</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>
     <UseIISExpress>true</UseIISExpress>
     <Use64BitIISExpress />
     <IISExpressSSLPort />
@@ -43,18 +43,18 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=7.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.Bcl.AsyncInterfaces.7.0.0\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>packages\Microsoft.Bcl.AsyncInterfaces.8.0.0\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=3.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.3.6.0\lib\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>
+    <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=4.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.4.1.0\lib\net472\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Web.Infrastructure, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>packages\Microsoft.Web.Infrastructure.2.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
     </Reference>
-    <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>packages\NLog.4.7.12\lib\net45\NLog.dll</HintPath>
+    <Reference Include="NLog, Version=5.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
+      <HintPath>packages\NLog.5.3.2\lib\net46\NLog.dll</HintPath>
     </Reference>
     <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
@@ -73,11 +73,11 @@
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
-    <Reference Include="System.Text.Encodings.Web, Version=7.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>packages\System.Text.Encodings.Web.7.0.0\lib\net462\System.Text.Encodings.Web.dll</HintPath>
+    <Reference Include="System.Text.Encodings.Web, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>packages\System.Text.Encodings.Web.8.0.0\lib\net462\System.Text.Encodings.Web.dll</HintPath>
     </Reference>
-    <Reference Include="System.Text.Json, Version=7.0.0.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>packages\System.Text.Json.7.0.2\lib\net462\System.Text.Json.dll</HintPath>
+    <Reference Include="System.Text.Json, Version=8.0.0.4, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>packages\System.Text.Json.8.0.4\lib\net462\System.Text.Json.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
@@ -92,26 +92,26 @@
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Web" />
+    <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Web.Helpers, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.AspNet.WebPages.3.2.9\lib\net45\System.Web.Helpers.dll</HintPath>
+      <HintPath>packages\Microsoft.AspNet.WebPages.3.3.0\lib\net45\System.Web.Helpers.dll</HintPath>
     </Reference>
-    <Reference Include="System.Web.Mvc, Version=5.2.9.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.AspNet.Mvc.5.2.9\lib\net45\System.Web.Mvc.dll</HintPath>
+    <Reference Include="System.Web.Mvc, Version=5.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>packages\Microsoft.AspNet.Mvc.5.3.0\lib\net45\System.Web.Mvc.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.AspNet.Razor.3.2.9\lib\net45\System.Web.Razor.dll</HintPath>
+      <HintPath>packages\Microsoft.AspNet.Razor.3.3.0\lib\net45\System.Web.Razor.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.WebPages, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.AspNet.WebPages.3.2.9\lib\net45\System.Web.WebPages.dll</HintPath>
+      <HintPath>packages\Microsoft.AspNet.WebPages.3.3.0\lib\net45\System.Web.WebPages.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.WebPages.Deployment, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.AspNet.WebPages.3.2.9\lib\net45\System.Web.WebPages.Deployment.dll</HintPath>
+      <HintPath>packages\Microsoft.AspNet.WebPages.3.3.0\lib\net45\System.Web.WebPages.Deployment.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.WebPages.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.AspNet.WebPages.3.2.9\lib\net45\System.Web.WebPages.Razor.dll</HintPath>
+      <HintPath>packages\Microsoft.AspNet.WebPages.3.3.0\lib\net45\System.Web.WebPages.Razor.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="System.Configuration" />
@@ -195,12 +195,12 @@
       </FlavorProperties>
     </VisualStudio>
   </ProjectExtensions>
-  <Import Project="packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.3.6.0\build\net472\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.targets" Condition="Exists('packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.3.6.0\build\net472\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.targets')" />
+  <Import Project="packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.4.1.0\build\net472\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.targets" Condition="Exists('packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.4.1.0\build\net472\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.3.6.0\build\net472\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.3.6.0\build\net472\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.targets'))" />
+    <Error Condition="!Exists('packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.4.1.0\build\net472\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.4.1.0\build\net472\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.targets'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/testApps/NLog_AspNet.Mvc/NLog_AspNet.Mvc.sln
+++ b/testApps/NLog_AspNet.Mvc/NLog_AspNet.Mvc.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30907.101
+# Visual Studio Version 17
+VisualStudioVersion = 17.9.34728.123
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NLog_AspNet.Mvc", "NLog_AspNet.Mvc.csproj", "{D16A173D-8F43-4C2F-B01C-C4EB86B4EECB}"
 EndProject
@@ -11,7 +11,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "KissLog.Adapters.NLog", "..
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "KissLog.CloudListeners", "..\..\src\KissLog.CloudListeners\KissLog.CloudListeners.csproj", "{9E0BF4B3-6153-4D2E-A0BC-511CAF2A1343}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KissLog.AspNet.Web", "..\..\src\KissLog.AspNet.Web\KissLog.AspNet.Web.csproj", "{D0C21C48-C253-41EB-A180-1253CA22381C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "KissLog.AspNet.Web", "..\..\src\KissLog.AspNet.Web\KissLog.AspNet.Web.csproj", "{D0C21C48-C253-41EB-A180-1253CA22381C}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "KissLog.RestClient", "..\..\src\KissLog.RestClient\KissLog.RestClient.csproj", "{1FD0F3DE-737D-4B0C-BF05-E7C3F4349D7A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -39,6 +41,10 @@ Global
 		{D0C21C48-C253-41EB-A180-1253CA22381C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D0C21C48-C253-41EB-A180-1253CA22381C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D0C21C48-C253-41EB-A180-1253CA22381C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1FD0F3DE-737D-4B0C-BF05-E7C3F4349D7A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1FD0F3DE-737D-4B0C-BF05-E7C3F4349D7A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1FD0F3DE-737D-4B0C-BF05-E7C3F4349D7A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1FD0F3DE-737D-4B0C-BF05-E7C3F4349D7A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/testApps/NLog_AspNet.Mvc/Web.config
+++ b/testApps/NLog_AspNet.Mvc/Web.config
@@ -1,54 +1,66 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0"?>
 <!--
   For more information on how to configure your ASP.NET application, please visit
   https://go.microsoft.com/fwlink/?LinkId=301880
   -->
 <configuration>
   <appSettings>
-    <add key="webpages:Version" value="3.0.0.0" />
-    <add key="webpages:Enabled" value="false" />
-    <add key="ClientValidationEnabled" value="true" />
-    <add key="UnobtrusiveJavaScriptEnabled" value="true" />
-    <add key="KissLog.OrganizationId" value="0337cd29-a56e-42c1-a48a-e900f3116aa8" />
-    <add key="KissLog.ApplicationId" value="4f729841-b103-460e-a87c-be6bd72f0cc9" />
-    <add key="KissLog.ApiUrl" value="https://api.kisslog.net" />
+    <add key="webpages:Version" value="3.0.0.0"/>
+    <add key="webpages:Enabled" value="false"/>
+    <add key="ClientValidationEnabled" value="true"/>
+    <add key="UnobtrusiveJavaScriptEnabled" value="true"/>
+    <add key="LogBee.OrganizationId" value="0337cd29-a56e-42c1-a48a-e900f3116aa8"/>
+    <add key="LogBee.ApplicationId" value="4f729841-b103-460e-a87c-be6bd72f0cc9"/>
+    <add key="LogBee.ApiUrl" value="https://api.logbee.net/"/>
   </appSettings>
+  <!--
+    For a description of web.config changes see http://go.microsoft.com/fwlink/?LinkId=235367.
+
+    The following attributes can be set on the <httpRuntime> tag.
+      <system.Web>
+        <httpRuntime targetFramework="4.8.1" />
+      </system.Web>
+  -->
   <system.web>
-    <compilation debug="true" targetFramework="4.7.2" />
-    <httpRuntime targetFramework="4.7.2" />
+    <compilation debug="true" targetFramework="4.8.1"/>
+    <httpRuntime targetFramework="4.7.2"/>
   </system.web>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+        <assemblyIdentity name="NLog" publicKeyToken="5120E14C03D0593C" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+        <assemblyIdentity name="Microsoft.Web.Infrastructure" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="1.0.0.0-5.2.9.0" newVersion="5.2.9.0" />
+        <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51"/>
+        <bindingRedirect oldVersion="1.0.0.0-7.0.0.2" newVersion="7.0.0.2"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Web.Infrastructure" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+        <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35"/>
+        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" />
-        <bindingRedirect oldVersion="1.0.0.0-7.0.0.2" newVersion="7.0.0.2" />
+        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35"/>
+        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35"/>
+        <bindingRedirect oldVersion="1.0.0.0-5.3.0.0" newVersion="5.3.0.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <system.codedom>
     <compilers>
-      <compiler extension=".cs" language="c#;cs;csharp" warningLevel="4" compilerOptions="/langversion:7.3 /nowarn:1659;1699;1701;612;618" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=3.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
-      <compiler extension=".vb" language="vb;vbs;visualbasic;vbscript" warningLevel="4" compilerOptions="/langversion:default /nowarn:41008,40000,40008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=3.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+      <compiler language="c#;cs;csharp" extension=".cs" warningLevel="4" compilerOptions="/langversion:default /nowarn:1659;1699;1701;612;618" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=4.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
+      <compiler language="vb;vbs;visualbasic;vbscript" extension=".vb" warningLevel="4" compilerOptions="/langversion:default /nowarn:41008,40000,40008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=4.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
     </compilers>
   </system.codedom>
 </configuration>

--- a/testApps/NLog_AspNet.Mvc/packages.config
+++ b/testApps/NLog_AspNet.Mvc/packages.config
@@ -1,18 +1,18 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.AspNet.Mvc" version="5.2.9" targetFramework="net472" />
-  <package id="Microsoft.AspNet.Razor" version="3.2.9" targetFramework="net472" />
-  <package id="Microsoft.AspNet.WebPages" version="3.2.9" targetFramework="net472" />
-  <package id="Microsoft.Bcl.AsyncInterfaces" version="7.0.0" targetFramework="net472" />
-  <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="3.6.0" targetFramework="net472" />
+  <package id="Microsoft.AspNet.Mvc" version="5.3.0" targetFramework="net472" />
+  <package id="Microsoft.AspNet.Razor" version="3.3.0" targetFramework="net472" />
+  <package id="Microsoft.AspNet.WebPages" version="3.3.0" targetFramework="net472" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="8.0.0" targetFramework="net472" />
+  <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="4.1.0" targetFramework="net472" />
   <package id="Microsoft.Web.Infrastructure" version="2.0.0" targetFramework="net472" />
-  <package id="NLog" version="4.7.12" targetFramework="net461" />
+  <package id="NLog" version="5.3.2" targetFramework="net472" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net461" />
   <package id="System.Memory" version="4.5.5" targetFramework="net472" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net461" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="net472" />
-  <package id="System.Text.Encodings.Web" version="7.0.0" targetFramework="net472" />
-  <package id="System.Text.Json" version="7.0.2" targetFramework="net472" />
+  <package id="System.Text.Encodings.Web" version="8.0.0" targetFramework="net472" />
+  <package id="System.Text.Json" version="8.0.4" targetFramework="net472" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net461" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net461" requireReinstallation="true" />
 </packages>

--- a/testApps/NLog_ConsoleApp_NetFramework/App.config
+++ b/testApps/NLog_ConsoleApp_NetFramework/App.config
@@ -1,18 +1,26 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8.1" />
     </startup>
     <appSettings>
-        <add key="KissLog.OrganizationId" value="0337cd29-a56e-42c1-a48a-e900f3116aa8" />
-        <add key="KissLog.ApplicationId" value="c91540a5-4041-42f8-99e6-f6cf6c98787c" />
-        <add key="KissLog.ApiUrl" value="https://api.kisslog.net" />
+      <add key="LogBee.OrganizationId" value="0337cd29-a56e-42c1-a48a-e900f3116aa8" />
+      <add key="LogBee.ApplicationId" value="4f729841-b103-460e-a87c-be6bd72f0cc9" />
+      <add key="LogBee.ApiUrl" value="https://api.logbee.net/" />
     </appSettings>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.4.0" newVersion="4.1.4.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/testApps/NLog_ConsoleApp_NetFramework/NLog_ConsoleApp_NetFramework.csproj
+++ b/testApps/NLog_ConsoleApp_NetFramework/NLog_ConsoleApp_NetFramework.csproj
@@ -8,10 +8,11 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>NLog_ConsoleApp_NetFramework</RootNamespace>
     <AssemblyName>NLog_ConsoleApp_NetFramework</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -33,11 +34,11 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=5.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.Bcl.AsyncInterfaces.5.0.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>packages\Microsoft.Bcl.AsyncInterfaces.8.0.0\lib\netstandard2.0\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
     </Reference>
-    <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>packages\NLog.4.7.12\lib\net45\NLog.dll</HintPath>
+    <Reference Include="NLog, Version=5.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
+      <HintPath>packages\NLog.5.3.2\lib\net46\NLog.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
@@ -46,23 +47,23 @@
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.IO.Compression" />
-    <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>packages\System.Memory.4.5.4\lib\net461\System.Memory.dll</HintPath>
+    <Reference Include="System.Memory, Version=4.0.1.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>packages\System.Memory.4.5.5\lib\net461\System.Memory.dll</HintPath>
     </Reference>
     <Reference Include="System.Numerics" />
     <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
     </Reference>
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>packages\System.Runtime.CompilerServices.Unsafe.5.0.0\lib\net45\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>packages\System.Runtime.CompilerServices.Unsafe.6.0.0\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
-    <Reference Include="System.Text.Encodings.Web, Version=5.0.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>packages\System.Text.Encodings.Web.5.0.1\lib\net461\System.Text.Encodings.Web.dll</HintPath>
+    <Reference Include="System.Text.Encodings.Web, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>packages\System.Text.Encodings.Web.8.0.0\lib\netstandard2.0\System.Text.Encodings.Web.dll</HintPath>
     </Reference>
-    <Reference Include="System.Text.Json, Version=5.0.0.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>packages\System.Text.Json.5.0.2\lib\net461\System.Text.Json.dll</HintPath>
+    <Reference Include="System.Text.Json, Version=8.0.0.4, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>packages\System.Text.Json.8.0.4\lib\net462\System.Text.Json.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>

--- a/testApps/NLog_ConsoleApp_NetFramework/Program.cs
+++ b/testApps/NLog_ConsoleApp_NetFramework/Program.cs
@@ -36,9 +36,9 @@ namespace NLog_ConsoleApp_NetFramework
             };
 
             KissLogConfiguration.Listeners
-                .Add(new RequestLogsApiListener(new Application(ConfigurationManager.AppSettings["KissLog.OrganizationId"], ConfigurationManager.AppSettings["KissLog.ApplicationId"]))
+                .Add(new RequestLogsApiListener(new Application(ConfigurationManager.AppSettings["LogBee.OrganizationId"], ConfigurationManager.AppSettings["LogBee.ApplicationId"]))
                 {
-                    ApiUrl = ConfigurationManager.AppSettings["KissLog.ApiUrl"],
+                    ApiUrl = ConfigurationManager.AppSettings["LogBee.ApiUrl"],
                     UseAsync = false
                 });
         }

--- a/testApps/NLog_ConsoleApp_NetFramework/packages.config
+++ b/testApps/NLog_ConsoleApp_NetFramework/packages.config
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Bcl.AsyncInterfaces" version="5.0.0" targetFramework="net461" />
-  <package id="NLog" version="4.7.12" targetFramework="net461" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="8.0.0" targetFramework="net461" requireReinstallation="true" />
+  <package id="NLog" version="5.3.2" targetFramework="net461" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net461" />
-  <package id="System.Memory" version="4.5.4" targetFramework="net461" />
+  <package id="System.Memory" version="4.5.5" targetFramework="net461" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net461" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="5.0.0" targetFramework="net461" />
-  <package id="System.Text.Encodings.Web" version="5.0.1" targetFramework="net461" />
-  <package id="System.Text.Json" version="5.0.2" targetFramework="net461" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="net461" />
+  <package id="System.Text.Encodings.Web" version="8.0.0" targetFramework="net461" requireReinstallation="true" />
+  <package id="System.Text.Json" version="8.0.4" targetFramework="net481" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net461" />
-  <package id="System.ValueTuple" version="4.5.0" targetFramework="net461" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net461" requireReinstallation="true" />
 </packages>

--- a/testApps/dotnet6_ConsoleApp/Program.cs
+++ b/testApps/dotnet6_ConsoleApp/Program.cs
@@ -68,9 +68,10 @@ IServiceProvider ConfigureServices(IConfiguration configuration)
 void ConfigureKissLog(IConfiguration configuration)
 {
     KissLogConfiguration.Listeners
-        .Add(new RequestLogsApiListener(new Application(configuration["KissLog.OrganizationId"], configuration["KissLog.ApplicationId"]))
+        .Add(new RequestLogsApiListener(new Application(configuration["LogBee.OrganizationId"], configuration["LogBee.ApplicationId"]))
         {
-            ApiUrl = configuration["KissLog.ApiUrl"]
+            ApiUrl = configuration["LogBee.ApiUrl"],
+            UseAsync = false
         });
 
     KissLogConfiguration.Listeners

--- a/testApps/dotnet6_ConsoleApp/appsettings.json
+++ b/testApps/dotnet6_ConsoleApp/appsettings.json
@@ -4,8 +4,7 @@
       "Default": "Trace"
     }
   },
-
-  "KissLog.OrganizationId": "0337cd29-a56e-42c1-a48a-e900f3116aa8",
-  "KissLog.ApplicationId": "4f729841-b103-460e-a87c-be6bd72f0cc9",
-  "KissLog.ApiUrl": "https://api.kisslog.net"
+  "LogBee.OrganizationId": "0337cd29-a56e-42c1-a48a-e900f3116aa8",
+  "LogBee.ApplicationId": "4f729841-b103-460e-a87c-be6bd72f0cc9",
+  "LogBee.ApiUrl": "https://api.logbee.net/"
 }

--- a/testApps/dotnet6_ConsoleApp/dotnet6_ConsoleApp.csproj
+++ b/testApps/dotnet6_ConsoleApp/dotnet6_ConsoleApp.csproj
@@ -8,12 +8,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/testApps/dotnet6_WebApp/Program.cs
+++ b/testApps/dotnet6_WebApp/Program.cs
@@ -39,9 +39,9 @@ app.MapControllerRoute(
 
 app.UseKissLogMiddleware(options => {
     options.Listeners
-        .Add(new RequestLogsApiListener(new Application(builder.Configuration["KissLog.OrganizationId"], builder.Configuration["KissLog.ApplicationId"]))
+        .Add(new RequestLogsApiListener(new Application(builder.Configuration["LogBee.OrganizationId"], builder.Configuration["LogBee.ApplicationId"]))
         {
-            ApiUrl = builder.Configuration["KissLog.ApiUrl"]
+            ApiUrl = builder.Configuration["LogBee.ApiUrl"]
         });
 
     options.Listeners

--- a/testApps/dotnet6_WebApp/appsettings.json
+++ b/testApps/dotnet6_WebApp/appsettings.json
@@ -6,7 +6,7 @@
     }
   },
   "AllowedHosts": "*",
-  "KissLog.OrganizationId": "0337cd29-a56e-42c1-a48a-e900f3116aa8",
-  "KissLog.ApplicationId": "4f729841-b103-460e-a87c-be6bd72f0cc9",
-  "KissLog.ApiUrl": "https://api.kisslog.net"
+  "LogBee.OrganizationId": "0337cd29-a56e-42c1-a48a-e900f3116aa8",
+  "LogBee.ApplicationId": "4f729841-b103-460e-a87c-be6bd72f0cc9",
+  "LogBee.ApiUrl": "https://api.logbee.net/"
 }

--- a/testApps/dotnetcore_3.1_ConsoleApp/Program.cs
+++ b/testApps/dotnetcore_3.1_ConsoleApp/Program.cs
@@ -78,9 +78,10 @@ namespace dotnetcore_3._1_ConsoleApp
         static void ConfigureKissLog(IConfiguration configuration)
         {
             KissLogConfiguration.Listeners
-                .Add(new RequestLogsApiListener(new Application(configuration["KissLog.OrganizationId"], configuration["KissLog.ApplicationId"]))
+                .Add(new RequestLogsApiListener(new Application(configuration["LogBee.OrganizationId"], configuration["LogBee.ApplicationId"]))
                 {
-                    ApiUrl = configuration["KissLog.ApiUrl"]
+                    ApiUrl = configuration["LogBee.ApiUrl"],
+                    UseAsync = false
                 });
 
             KissLogConfiguration.Listeners

--- a/testApps/dotnetcore_3.1_ConsoleApp/Program_simple.cs
+++ b/testApps/dotnetcore_3.1_ConsoleApp/Program_simple.cs
@@ -77,9 +77,10 @@ namespace dotnetcore_3._1_ConsoleApp
         static void ConfigureKissLog(IConfiguration configuration)
         {
             KissLogConfiguration.Listeners
-                .Add(new RequestLogsApiListener(new Application(configuration["KissLog.OrganizationId"], configuration["KissLog.ApplicationId"]))
+                .Add(new RequestLogsApiListener(new Application(configuration["LogBee.OrganizationId"], configuration["LogBee.ApplicationId"]))
                 {
-                    ApiUrl = configuration["KissLog.ApiUrl"]
+                    ApiUrl = configuration["LogBee.ApiUrl"],
+                    UseAsync = false
                 });
 
             KissLogConfiguration.Listeners

--- a/testApps/dotnetcore_3.1_ConsoleApp/appsettings.json
+++ b/testApps/dotnetcore_3.1_ConsoleApp/appsettings.json
@@ -5,7 +5,7 @@
     }
   },
 
-  "KissLog.OrganizationId": "0337cd29-a56e-42c1-a48a-e900f3116aa8",
-  "KissLog.ApplicationId": "70632bac-7c20-446e-9109-49b4f91203f2",
-  "KissLog.ApiUrl": "https://api.kisslog.net"
+  "LogBee.OrganizationId": "0337cd29-a56e-42c1-a48a-e900f3116aa8",
+  "LogBee.ApplicationId": "4f729841-b103-460e-a87c-be6bd72f0cc9",
+  "LogBee.ApiUrl": "https://api.logbee.net/"
 }

--- a/testApps/dotnetcore_3.1_WebApp/Startup.cs
+++ b/testApps/dotnetcore_3.1_WebApp/Startup.cs
@@ -79,9 +79,9 @@ namespace dotnetcore_3._1_WebApp
         private void ConfigureKissLog(IOptionsBuilder options)
         {
             options.Listeners
-                .Add(new RequestLogsApiListener(new Application(Configuration["KissLog.OrganizationId"], Configuration["KissLog.ApplicationId"]))
+                .Add(new RequestLogsApiListener(new Application(Configuration["LogBee.OrganizationId"], Configuration["LogBee.ApplicationId"]))
                 {
-                    ApiUrl = Configuration["KissLog.ApiUrl"]
+                    ApiUrl = Configuration["LogBee.ApiUrl"]
                 });
 
             options.Listeners

--- a/testApps/dotnetcore_3.1_WebApp/appsettings.json
+++ b/testApps/dotnetcore_3.1_WebApp/appsettings.json
@@ -8,7 +8,7 @@
   },
   "AllowedHosts": "*",
 
-  "KissLog.OrganizationId": "0337cd29-a56e-42c1-a48a-e900f3116aa8",
-  "KissLog.ApplicationId": "4f729841-b103-460e-a87c-be6bd72f0cc9",
-  "KissLog.ApiUrl": "https://api.kisslog.net"
+  "LogBee.OrganizationId": "0337cd29-a56e-42c1-a48a-e900f3116aa8",
+  "LogBee.ApplicationId": "4f729841-b103-460e-a87c-be6bd72f0cc9",
+  "LogBee.ApiUrl": "https://api.logbee.net/"
 }

--- a/testApps/examples/EntityFrameworkValidationExample/EntityFrameworkValidationExample.csproj
+++ b/testApps/examples/EntityFrameworkValidationExample/EntityFrameworkValidationExample.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="EntityFramework" Version="6.4.4" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
+    <PackageReference Include="EntityFramework" Version="6.5.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/testApps/examples/MongoDbListenerExample/MongoDbListenerExample.csproj
+++ b/testApps/examples/MongoDbListenerExample/MongoDbListenerExample.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MongoDB.Driver" Version="2.13.2" />
+    <PackageReference Include="MongoDB.Driver" Version="2.28.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/testApps/netframework_ConsoleApp/App.config
+++ b/testApps/netframework_ConsoleApp/App.config
@@ -4,8 +4,8 @@
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
   </startup>
   <appSettings>
-    <add key="KissLog.OrganizationId" value="0337cd29-a56e-42c1-a48a-e900f3116aa8" />
-    <add key="KissLog.ApplicationId" value="4f729841-b103-460e-a87c-be6bd72f0cc9" />
-    <add key="KissLog.ApiUrl" value="https://api.kisslog.net" />
+    <add key="LogBee.OrganizationId" value="0337cd29-a56e-42c1-a48a-e900f3116aa8" />
+    <add key="LogBee.ApplicationId" value="4f729841-b103-460e-a87c-be6bd72f0cc9" />
+    <add key="LogBee.ApiUrl" value="https://api.logbee.net/" />
   </appSettings>
 </configuration>

--- a/testApps/netframework_ConsoleApp/Program.cs
+++ b/testApps/netframework_ConsoleApp/Program.cs
@@ -37,9 +37,9 @@ namespace netframework_ConsoleApp
         static void ConfigureKissLog()
         {
             KissLogConfiguration.Listeners
-                .Add(new RequestLogsApiListener(new Application(ConfigurationManager.AppSettings["KissLog.OrganizationId"], ConfigurationManager.AppSettings["KissLog.ApplicationId"]))
+                .Add(new RequestLogsApiListener(new Application(ConfigurationManager.AppSettings["LogBee.OrganizationId"], ConfigurationManager.AppSettings["LogBee.ApplicationId"]))
                 {
-                    ApiUrl = ConfigurationManager.AppSettings["KissLog.ApiUrl"],
+                    ApiUrl = ConfigurationManager.AppSettings["LogBee.ApiUrl"],
                     UseAsync = false
                 });
 

--- a/testApps/netframework_ConsoleApp/netframework_ConsoleApp.csproj
+++ b/testApps/netframework_ConsoleApp/netframework_ConsoleApp.csproj
@@ -35,19 +35,20 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
-    <Reference Include="System.Configuration.ConfigurationManager, Version=5.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>packages\System.Configuration.ConfigurationManager.5.0.0\lib\net461\System.Configuration.ConfigurationManager.dll</HintPath>
+    <Reference Include="System.Configuration.ConfigurationManager, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>packages\System.Configuration.ConfigurationManager.8.0.0\lib\net462\System.Configuration.ConfigurationManager.dll</HintPath>
     </Reference>
     <Reference Include="System.Core" />
     <Reference Include="System.Data.OracleClient" />
+    <Reference Include="System.DirectoryServices" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Net" />
     <Reference Include="System.Security" />
-    <Reference Include="System.Security.AccessControl, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>packages\System.Security.AccessControl.5.0.0\lib\net461\System.Security.AccessControl.dll</HintPath>
+    <Reference Include="System.Security.AccessControl, Version=6.0.0.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>packages\System.Security.AccessControl.6.0.1\lib\net461\System.Security.AccessControl.dll</HintPath>
     </Reference>
-    <Reference Include="System.Security.Permissions, Version=5.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>packages\System.Security.Permissions.5.0.0\lib\net461\System.Security.Permissions.dll</HintPath>
+    <Reference Include="System.Security.Permissions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>packages\System.Security.Permissions.8.0.0\lib\net462\System.Security.Permissions.dll</HintPath>
     </Reference>
     <Reference Include="System.Security.Principal.Windows, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>packages\System.Security.Principal.Windows.5.0.0\lib\net461\System.Security.Principal.Windows.dll</HintPath>

--- a/testApps/netframework_ConsoleApp/packages.config
+++ b/testApps/netframework_ConsoleApp/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Configuration.ConfigurationManager" version="5.0.0" targetFramework="net472" />
-  <package id="System.Security.AccessControl" version="5.0.0" targetFramework="net472" />
-  <package id="System.Security.Permissions" version="5.0.0" targetFramework="net472" />
+  <package id="System.Configuration.ConfigurationManager" version="8.0.0" targetFramework="net472" />
+  <package id="System.Security.AccessControl" version="6.0.1" targetFramework="net472" />
+  <package id="System.Security.Permissions" version="8.0.0" targetFramework="net472" />
   <package id="System.Security.Principal.Windows" version="5.0.0" targetFramework="net472" />
 </packages>

--- a/tests/KissLog.AspNet.Mvc.Tests/KissLog.AspNet.Mvc.Tests.csproj
+++ b/tests/KissLog.AspNet.Mvc.Tests/KissLog.AspNet.Mvc.Tests.csproj
@@ -6,11 +6,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="3.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/KissLog.AspNet.Web.Tests/KissLog.AspNet.Web.Tests.csproj
+++ b/tests/KissLog.AspNet.Web.Tests/KissLog.AspNet.Web.Tests.csproj
@@ -6,11 +6,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="3.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/KissLog.AspNet.WebApi.Tests/KissLog.AspNet.WebApi.Tests.csproj
+++ b/tests/KissLog.AspNet.WebApi.Tests/KissLog.AspNet.WebApi.Tests.csproj
@@ -6,11 +6,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="3.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/KissLog.AspNetCore.Tests/KissLog.AspNetCore.Tests.csproj
+++ b/tests/KissLog.AspNetCore.Tests/KissLog.AspNetCore.Tests.csproj
@@ -6,11 +6,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="3.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/KissLog.CloudListeners.Tests/KissLog.CloudListeners.Tests.csproj
+++ b/tests/KissLog.CloudListeners.Tests/KissLog.CloudListeners.Tests.csproj
@@ -7,11 +7,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="3.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/KissLog.CloudListeners.Tests/RequestLogsListener/RequestLogsApiListenerTests.cs
+++ b/tests/KissLog.CloudListeners.Tests/RequestLogsListener/RequestLogsApiListenerTests.cs
@@ -29,7 +29,7 @@ namespace KissLog.CloudListeners.Tests.RequestLogsListener
             var application = new Application("organizationId", "applicationId");
             var listener = new RequestLogsApiListener(application);
 
-            Assert.AreEqual(Constants.KissLogApiUrl, listener.ApiUrl);
+            Assert.AreEqual(Constants.LogBeeApiUrl, listener.ApiUrl);
         }
 
         [TestMethod]

--- a/tests/KissLog.RestClient.Tests/KissLog.RestClient.Tests.csproj
+++ b/tests/KissLog.RestClient.Tests/KissLog.RestClient.Tests.csproj
@@ -6,10 +6,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="3.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/KissLog.Tests/KissLog.Tests.csproj
+++ b/tests/KissLog.Tests/KissLog.Tests.csproj
@@ -14,7 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Text.Json" Version="8.0.3" />
+    <PackageReference Include="System.Text.Json" Version="8.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/KissLog.Tests/LoggerData/FilesContainerTests.cs
+++ b/tests/KissLog.Tests/LoggerData/FilesContainerTests.cs
@@ -238,7 +238,7 @@ namespace KissLog.Tests.LoggerData
             LogMessage message = logger.DataContainer.LogMessages.FirstOrDefault();
 
             Assert.IsNotNull(message);
-            Assert.AreEqual(LogLevel.Error, message.LogLevel);
+            Assert.AreEqual(LogLevel.Debug, message.LogLevel);
             Assert.IsTrue(message.Message.Contains(ex.Message));
         }
 
@@ -259,7 +259,7 @@ namespace KissLog.Tests.LoggerData
             LogMessage message = logger.DataContainer.LogMessages.FirstOrDefault();
 
             Assert.IsNotNull(message);
-            Assert.AreEqual(LogLevel.Error, message.LogLevel);
+            Assert.AreEqual(LogLevel.Debug, message.LogLevel);
             Assert.IsTrue(message.Message.Contains(ex.Message));
         }
 
@@ -285,7 +285,7 @@ namespace KissLog.Tests.LoggerData
             LogMessage message = logger.DataContainer.LogMessages.FirstOrDefault();
 
             Assert.IsNotNull(message);
-            Assert.AreEqual(LogLevel.Error, message.LogLevel);
+            Assert.AreEqual(LogLevel.Debug, message.LogLevel);
             Assert.IsTrue(message.Message.Contains(ex.Message));
         }
 
@@ -309,7 +309,7 @@ namespace KissLog.Tests.LoggerData
             LogMessage message = logger.DataContainer.LogMessages.FirstOrDefault();
 
             Assert.IsNotNull(message);
-            Assert.AreEqual(LogLevel.Error, message.LogLevel);
+            Assert.AreEqual(LogLevel.Debug, message.LogLevel);
             Assert.IsTrue(message.Message.Contains(ex.Message));
         }
     }

--- a/tests/adapters/KissLog.Adapters.NLog.Tests/KissLog.Adapters.NLog.Tests.csproj
+++ b/tests/adapters/KissLog.Adapters.NLog.Tests/KissLog.Adapters.NLog.Tests.csproj
@@ -6,11 +6,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="3.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/adapters/KissLog.Adapters.log4net.Tests/KissLog.Adapters.log4net.Tests.csproj
+++ b/tests/adapters/KissLog.Adapters.log4net.Tests/KissLog.Adapters.log4net.Tests.csproj
@@ -5,11 +5,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="3.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- changed internal warning logs to `Debug`, as they were polluting the (real) custom logs created by the application
- updated the default endpoint from `https://api.kisslog.net` to `https://api.logbee.net`
- updated NuGet dependencies